### PR TITLE
fix: load environment variables before using stripe

### DIFF
--- a/Updated1
+++ b/Updated1
@@ -144,8 +144,8 @@ module.exports = mongoose.models.Booking || mongoose.model('Booking', bookingSch
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
-const stripe = require('stripe')(process.env.STRIPE_SECRET);
 require('dotenv').config();
+const stripe = require('stripe')(process.env.STRIPE_SECRET);
 const Booking = require('./models/Booking');
 
 const app = express();


### PR DESCRIPTION
## Summary
- load env vars before requiring Stripe so keys are available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e12788cc8331bf3fd0388e101434